### PR TITLE
local variable 'connect_client' referenced before assignment

### DIFF
--- a/projects/AWSSCV-VoicemailExpress/Code/awsscv_vmx_packager.py
+++ b/projects/AWSSCV-VoicemailExpress/Code/awsscv_vmx_packager.py
@@ -99,6 +99,8 @@ def lambda_handler(event, context):
             continue
 
         # Determine the queue/agent name
+        connect_client = boto3.client('connect')
+
         if loaded_tags['vm_queue_type'] == 'agent':
             vm_prefix = 'Direct'
             try:
@@ -107,7 +109,6 @@ def lambda_handler(event, context):
                 instance_id = split_1.split('/queue')[0]
                 agent_id = split_1.split('agent/')[1]
 
-                connect_client = boto3.client('connect')
                 get_agent = connect_client.describe_user(
                     UserId=agent_id,
                     InstanceId=instance_id


### PR DESCRIPTION
Prevent local variable 'connect_client' referenced before assignment when using queue voicemail instead of agent
Error was thrown in try with comment # Clear the vm_flag for this contact (line 184)

*Description of changes:*
Moved connect_client assignment outside actor check (agent vs queue) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
