### PR TITLE
Reverted awsscv version to 1.0.0

### DIFF
--- a/Common/AWSSCV-CommonLayers/Code/python-layer/python/lib/python3.8/site-packages/requirements.txt
+++ b/Common/AWSSCV-CommonLayers/Code/python-layer/python/lib/python3.8/site-packages/requirements.txt
@@ -1,4 +1,4 @@
-awsscv==1.0.1
+awsscv==1.0.0
 requests
 pyjwt[crypto]
 phonenumbers


### PR DESCRIPTION
Reverted AWSSCV python package to 1.0.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
