### PR TITLE
Updates to AWSSCV-CommonLayers and AWSSCV-SalesforceConfig

### DIFF
--- a/Common/AWSSCV-CommonLayers/Code/python-layer/python/lib/python3.8/site-packages/requirements.txt
+++ b/Common/AWSSCV-CommonLayers/Code/python-layer/python/lib/python3.8/site-packages/requirements.txt
@@ -1,4 +1,4 @@
-awsscv==1.0.0
+awsscv==1.0.1
 requests
 pyjwt[crypto]
 phonenumbers

--- a/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
+++ b/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
@@ -51,7 +51,7 @@ Parameters:
         - PROD
         - DEV
         - SANDBOX
-      Description: The mode of the Salesforce org
+      Description: The type of Salesforce org
 Resources:
     awsscvcommonsecrets:
         Type: AWS::SecretsManager::Secret

--- a/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
+++ b/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
@@ -44,6 +44,14 @@ Parameters:
         Default: REPLACEME
         Description: The entire contents of the encoded_key.txt file that you generated as a part of the setup process
         NoEcho: true
+    sfMode:
+      Type: String
+      Default: PROD
+      AllowedValues:
+        - PROD
+        - DEV
+        - SANDBOX
+      Description: The mode of the Salesforce org
 Resources:
     awsscvcommonsecrets:
         Type: AWS::SecretsManager::Secret
@@ -55,7 +63,7 @@ Resources:
                   - !Ref ConnectInstanceName
           Description: Required credentials to access Salesforce
           SecretString: !Sub
-            - '{"OAuthToken":"${OT}","ConsumerKey":"${CK}","Username":"${UN}","OrgId":"${OI}","Host":"${SH}","PrivateKey":"${PK}","Version":"${VR}"}'
+            - '{"OAuthToken":"${OT}","ConsumerKey":"${CK}","Username":"${UN}","OrgId":"${OI}","Host":"${SH}","PrivateKey":"${PK}","Version":"${VR}", "Mode":"${MD}"}'
             - OT: PLACEHOLDER
               CK: !Ref sfConsumerKey
               UN: !Ref sfUsername
@@ -63,6 +71,7 @@ Resources:
               SH: !Ref sfHost
               PK: !Ref sfPrivateKey
               VR: !Ref sfVersion
+              MD: !Ref sfMode
     awsscvcommonsecretspolicy:
         Type: AWS::IAM::ManagedPolicy
         DependsOn:

--- a/Common/AWSSCV-SalesforceConfig/readme.md
+++ b/Common/AWSSCV-SalesforceConfig/readme.md
@@ -108,6 +108,7 @@ To ensure that your Salesforce credentials are secure, the Lambdas require that 
  - sfOrgId: Provide your Salesforce.com Organization ID
  - sfPrivateKey: The contents of the encoded_key.txt that you generated as a part of the setup process.
  - sfUsername: Your awsutil username
+ - sfMode: The type of Salesforce org (PROD, DEV, SANDBOX)
 12.	Select Next
 13.	In Service Cloud Voice deployments, it is normal to see a warning on the next page, Configure stack options
 14.	Scroll to the bottom and select Next


### PR DESCRIPTION
Updates to AWSSCV-CommonLayers to allow for use in Salesforce sandboxes.

Updates to AWSSCV-SalesforceConfig to gather and store Salesforce org type (PROD, DEV, SANDBOX)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
