### PR TITLE
Add selection of Salesforce environment type

### DIFF
--- a/Solutions/AWSSCV-VoicemailExpress/CloudFormation/awsscv_vmx.yaml
+++ b/Solutions/AWSSCV-VoicemailExpress/CloudFormation/awsscv_vmx.yaml
@@ -49,6 +49,14 @@ Parameters:
           - CTI
           - SCV
         Description: Is this a CTI Adapter configuration or Service Cloud Voice?
+    sfOrgType:
+        Type: String
+        Default: PROD
+        AllowedValues:
+          - PROD
+          - DEV
+          - SANDBOX
+        Description: What is the type of Salesforce Org?
     sfVoicemailField:
         Type: String
         Default: vm_link__c


### PR DESCRIPTION
Users should also be allowed to select the type of Salesforce environment. I could not see any parameters in the Cloudformation template, hence I have added it here.

Also note though the "sf_is_production" environment variable has been added to the "AWSSCV_vmx_packager_*" function, still the function is running into error. The reason to this is that "Mode" variable in "sf_config.py" file in the python layer has been set to "Mode", the value of which is picked from "awsscv_salesforce_config_*" entry in secret manager. I could not find any variable with the name "Mode" in this this entry. Hence I think the there should be an addition of "Mode" variable to the "awsscv_salesforce_config_*" secret entry while deploying the Voicemail solution.


**Error seen with new Voicemail solution:**

```
Traceback (most recent call last):
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 108, in execute
return method(**kwargs, headers=self.headers)
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 123, in post
return __check_resp__(r)
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 162, in __check_resp__
raise AuthError('')
awsscv.sf_auth.AuthError
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/var/task/awsscv_vmx_packager.py", line 162, in lambda_handler
response = sf.create(sobject='Case', data=data)
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 73, in create
resp = self.execute(self.request.post,
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 110, in execute
self.init_request(refresh=True)
File "/opt/python/lib/python3.8/site-packages/awsscv/sf.py", line 100, in init_request
self.access_token = SalesforceAuth().get_access_token(refresh=refresh)
File "/opt/python/lib/python3.8/site-packages/awsscv/sf_auth.py", line 34, in get_access_token
mode = settings[SalesforceConfig.MODE_PROP]
KeyError: 'Mode'
Record 1 Result: Failed to create case
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
