### PR TITLE
Moved salesforce validator Lambda to external source rather than inline

### DIFF
--- a/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
+++ b/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv-ssm.yaml
@@ -123,60 +123,23 @@ Resources:
         - awsscvcommonrole
       Properties:
         Code:
-          ZipFile: >
-            """
-            **********************************************************************************************************************
-             *  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved                                            *
-             *                                                                                                                    *
-             *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated      *
-             *  documentation files (the "Software"), to deal in the Software without restriction, including without limitation   *
-             *  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and  *
-             *  to permit persons to whom the Software is furnished to do so.                                                     *
-             *                                                                                                                    *
-             *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO  *
-             *  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
-             *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF         *
-             *  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS *
-             *  IN THE SOFTWARE.                                                                                                  *
-             **********************************************************************************************************************
-            """
-
-            import logging
-            from awsscv.sf import Salesforce
-
-            logger = logging.getLogger()
-            logger.setLevel(logging.getLevelName(os.getenv('lambda_logging_level', 'INFO')))
-
-            def lambda_handler(event, context):
-                logger.debug(event)
-
-                try:
-                    sf = Salesforce()
-                    qr = sf.query("SELECT Id, Username FROM User LIMIT 1")
-
-                    return {
-                        "Status": "SUCCESS"
-                    }
-
-                except Exception as e:
-                    return {
-                        "Status": "FAILURE",
-                        "Reason": str(e)
-                    }
-
+          S3Bucket:
+            !Join
+            - ''
+            - - 'awsscv-supporting-code-'
+              - !Ref AWSRegion
+          S3Key: awsscv_salesforce_validator.zip
         Description: Validates Salesforce connectivity and authentication via SOQL query.
         Environment:
           Variables:
             sf_config_sm_arn:
               Ref: awsscvcommonsecrets
-            region:
-              Ref: AWSRegion
         FunctionName:
           !Join
           - ''
           - - 'AWSSCV_salesforce_validator_'
             - !Ref ConnectInstanceName
-        Handler: index.lambda_handler
+        Handler: awsscv_salesforce_validator.lambda_handler
         Role: !GetAtt awsscvcommonrole.Arn
         Layers: [ !Ref AWSSalesforceCommonPythonLayer ]
         Runtime: python3.8

--- a/Common/AWSSCV-SalesforceConfig/Code/awsscv_salesforce_validator/awsscv_salesforce_validator.py
+++ b/Common/AWSSCV-SalesforceConfig/Code/awsscv_salesforce_validator/awsscv_salesforce_validator.py
@@ -1,36 +1,39 @@
 """
 **********************************************************************************************************************
- *  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved                                            *
- *                                                                                                                    *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated      *
- *  documentation files (the "Software"), to deal in the Software without restriction, including without limitation   *
- *  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and  *
- *  to permit persons to whom the Software is furnished to do so.                                                     *
- *                                                                                                                    *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO  *
- *  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF         *
- *  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS *
- *  IN THE SOFTWARE.                                                                                                  *
- **********************************************************************************************************************
+*  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved                                            *
+*                                                                                                                    *
+*  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated      *
+*  documentation files (the "Software"), to deal in the Software without restriction, including without limitation   *
+*  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and  *
+*  to permit persons to whom the Software is furnished to do so.                                                     *
+*                                                                                                                    *
+*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO  *
+*  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+*  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF         *
+*  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS *
+*  IN THE SOFTWARE.                                                                                                  *
+**********************************************************************************************************************
 """
 
-# Import the necessary moduels for this flow to work
+import os, logging
 from awsscv.sf import Salesforce
 
+logger = logging.getLogger()
+logger.setLevel(logging.getLevelName(os.getenv('lambda_logging_level', 'INFO')))
+
 def lambda_handler(event, context):
+    logger.debug(event)
 
     try:
         sf = Salesforce()
         qr = sf.query("SELECT Id, Username FROM User LIMIT 1")
 
         return {
-            "success": True,
-            "message": "Salesforce connectivity validation was successful."
+            "Status": "SUCCESS"
         }
 
     except Exception as e:
         return {
-            "success": False,
-            "message": "Salesforce connectivity validation failed. {}".format(str(e))
+            "Status": "FAILURE",
+            "Reason": str(e)
         }

--- a/Common/AWSSCV-SalesforceConfig/Code/awsscv_salesforce_validator/awsscv_salesforce_validator.py
+++ b/Common/AWSSCV-SalesforceConfig/Code/awsscv_salesforce_validator/awsscv_salesforce_validator.py
@@ -28,11 +28,15 @@ def lambda_handler(event, context):
         sf = Salesforce()
         qr = sf.query("SELECT Id, Username FROM User LIMIT 1")
 
+        logger.debug(qr)
+
         return {
             "Status": "SUCCESS"
         }
 
     except Exception as e:
+        logger.error(e)
+
         return {
             "Status": "FAILURE",
             "Reason": str(e)


### PR DESCRIPTION
Moved salesforce validator Lambda to external source rather than inline


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
