### PR TITLE
Update awsscv_vmx_packager.py

### DIFF
--- a/Solutions/AWSSCV-VoicemailExpress/Code/awsscv_vmx_packager/awsscv_vmx_packager.py
+++ b/Solutions/AWSSCV-VoicemailExpress/Code/awsscv_vmx_packager/awsscv_vmx_packager.py
@@ -124,7 +124,10 @@ def lambda_handler(event, context):
                 logger.debug(get_agent['User']['IdentityInfo'])
                 entity_name = get_agent['User']['IdentityInfo']['FirstName']+' '+get_agent['User']['IdentityInfo']['LastName']
                 full_agent_id = get_agent['User']['Username']
-                sf_agent_id = full_agent_id.split('@')[0]
+                if full_agent_id.count('@') == 1:
+                    sf_agent_id = full_agent_id.split('@')[0]
+                else:
+                    sf_agent_id = full_agent_id.split('@')[1]
 
             except Exception as e:
                 logger.error(e)


### PR DESCRIPTION
Just picked this up on my latest prod build

newly created SCV implementations are using the following format for AgentID
<user.alias>@<User.id>@<org.id>
whereas old orgs are still using
<User.id>@<org.id>

this looks to affect the VMX packager where the voicemail is for an agent; the code currently gets the aws agentId and does a split(@) [0] which in the original format returns the user.id but in the new format returns the alias

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
