### PR TITLE
Fix some CloudFormation nested stack description typos

### DIFF
--- a/Archive/AWSSCV-CommonLayers/CloudFormation/awsscv_common_layers.yaml
+++ b/Archive/AWSSCV-CommonLayers/CloudFormation/awsscv_common_layers.yaml
@@ -91,7 +91,7 @@ Resources:
               - - 'common_layers/'
                 - !Ref EXPTemplateVersion
                 - /zip/awsscv_common_node.zip
-          Description: Provides dependencies code and functions for node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
+          Description: Provides dependencies code and functions for Node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
           LayerName: awsscv_common_node
           LicenseInfo: https://aws.amazon.com/apache-2-0
 Outputs:
@@ -99,5 +99,5 @@ Outputs:
     Description: ARN for the Python common layer
     Value: !Ref SCVCommonPythonLayer
   SCVCommonNodeLayerARN:
-    Description: ARN for the node.js common layer
+    Description: ARN for the Node.js common layer
     Value: !Ref SCVCommonNodeLayer

--- a/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv_sc.yaml
+++ b/Common/AWSSCV-SalesforceConfig/CloudFormation/awsscv_sc.yaml
@@ -242,7 +242,7 @@ Resources:
               - - 'sf_layers/'
                 - !Ref EXPTemplateVersion
                 - /zip/awsscv_common_node.zip
-          Description: Provides dependencies code and functions for node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
+          Description: Provides dependencies code and functions for Node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
           LayerName: !Join
             - ''
             - - 'common_node_layer_'
@@ -291,7 +291,7 @@ Outputs:
     Description: ARN for the Python common layer
     Value: !Ref SCVCommonPythonLayer
   SCVCommonNodeLayerARN:
-    Description: ARN for the node.js common layer
+    Description: ARN for the Node.js common layer
     Value: !Ref SCVCommonNodeLayer
   SCVSalesforceValidator:
     Description: Execute this Lambda function to validate the Salesforce configuration.

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-lambda-functions.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-lambda-functions.yaml
@@ -131,7 +131,7 @@ Resources:
           - - 'sf_layers/'
             - !Ref EXPTemplateVersion
             - /zip/awsscv_common_node.zip
-      Description: Provides dependencies code and functions for node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
+      Description: Provides dependencies code and functions for Node.js Lambda functions that augment the Service Cloud Voice offering from Salesforce
       LayerName: !Join
         - ''
         - - 'common_node_layer_'

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-lambda-functions.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-lambda-functions.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Deploys and configures the triggers for the Vociemail Express solution.
+Description: Deploys the Voicemail Express Lambda functions.
 
 Parameters:
   EXPTemplateVersion:

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-triggers.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-triggers.yaml
@@ -53,7 +53,7 @@ Resources:
       StartingPosition: LATEST
 
   CreateTranscriptTrigger:
-    Type: 'Custom::TranscriptTrigger'
+    Type: Custom::TranscriptTrigger
     DependsOn:
       - RecordingsBucketPermission
     Properties:
@@ -63,7 +63,7 @@ Resources:
       object_suffix: .wav
 
   CreatePackagerTrigger:
-    Type: 'Custom::PackagerTrigger'
+    Type: Custom::PackagerTrigger
     DependsOn:
       - TranscriptsBucketPermission
     Properties:

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-triggers.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-triggers.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Deploys and configures the triggers for the Vociemail Express solution.
+Description: Deploys the Voicemail Express content triggers.
 
 Parameters:
   EXPTemplateVersion:


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

- Noted two typos in the descriptions of the nested [`VMX2-VoicemailExpress`](https://github.com/magnetikonline/amazon-connect-salesforce-scv/tree/master/Solutions/VMX2-VoicemailExpress) stacks.
- Also updated wording to better match that of the other nested stacks.
- Dropped some quotes that aren't required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
