### PR TITLE
Drop unrequired CloudFormation parameters from VMX2 stack

### DIFF
--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-contactflows.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-contactflows.yaml
@@ -16,16 +16,6 @@ Parameters:
     Type: String
   EnableVMToSalesforceCustomObject:
     Type: String
-  SalesforceCallbackPhoneField:
-    Type: String
-  SalesforceContactAttributesField:
-    Type: String
-  SalesforceVoicemailLinkField:
-    Type: String
-  VMToEmailDefaultFrom:
-    Type: String
-  VMToEmailDefaultTo:
-    Type: String
   VMTestAgentId:
     Type: String
   VMTestQueueARN:

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-contactflows.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx-contactflows.yaml
@@ -25,7 +25,6 @@ Conditions:
   SalesforceEnabled: !Or [!Equals [!Ref EnableVMToSalesforceCase, yes], !Equals [!Ref EnableVMToSalesforceCustomObject, yes] ]
   AWSEnabled: !Or [!Equals [!Ref EnableVMToConnectTask, yes], !Equals [!Ref EnableVMToEmail, yes] ]
   ConnectTasksEnabled: !Equals [!Ref EnableVMToConnectTask, yes]
-  AWSEmailEnabled: !Equals [!Ref EnableVMToEmail, yes]
 
 Resources:
   VMXCoreFlow:

--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx.yaml
@@ -312,13 +312,8 @@ Resources:
         EnableVMToSalesforceCase: !Ref EnableVMToSalesforceCase
         EnableVMToSalesforceCustomObject: !Ref EnableVMToSalesforceCustomObject
         EXPTemplateVersion: !Ref EXPTemplateVersion
-        SalesforceCallbackPhoneField: !Ref SalesforceCallbackPhoneField
-        SalesforceContactAttributesField: !Ref SalesforceContactAttributesField
-        SalesforceVoicemailLinkField: !Ref SalesforceVoicemailLinkField
         VMTestAgentId: !Ref VMTestAgentId
         VMTestQueueARN: !Ref VMTestQueueARN
-        VMToEmailDefaultFrom: !Ref VMToEmailDefaultFrom
-        VMToEmailDefaultTo: !Ref VMToEmailDefaultFrom
       TemplateURL:
         !Join
         - ''


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

I noted this typo in a deployed instance of this stack:

```yaml
VMXContactFlowStack:
  Type: AWS::CloudFormation::Stack
  Properties:
    Parameters:
      ConnectInstanceAlias: !Ref ConnectInstanceAlias
      ConnectInstanceARN: !Ref ConnectInstanceARN
      EnableVMToConnectTask: !Ref EnableVMToConnectTask
      EnableVMToEmail: !Ref EnableVMToEmail
      EnableVMToSalesforceCase: !Ref EnableVMToSalesforceCase
      EnableVMToSalesforceCustomObject: !Ref EnableVMToSalesforceCustomObject
      EXPTemplateVersion: !Ref EXPTemplateVersion
      SalesforceCallbackPhoneField: !Ref SalesforceCallbackPhoneField
      SalesforceContactAttributesField: !Ref SalesforceContactAttributesField
      SalesforceVoicemailLinkField: !Ref SalesforceVoicemailLinkField
      VMTestAgentId: !Ref VMTestAgentId
      VMTestQueueARN: !Ref VMTestQueueARN
      VMToEmailDefaultFrom: !Ref VMToEmailDefaultFrom
      VMToEmailDefaultTo: !Ref VMToEmailDefaultFrom
```

Note the double up/typo of `VMToEmailDefaultFrom`.

So once digging in - determined that this parameter, plus a few others aren't actually used by the nested stack. So have cleaned them up/removed them.

Also noted the `AWSEmailEnabled` Condition isn't used in the contact flows stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
