### PR TITLE
Fix use of `VMToEmailDefaultFrom` -> `VMToEmailDefaultTo` in CloudFormation stack parameter

### DIFF
--- a/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx.yaml
+++ b/Solutions/VMX2-VoicemailExpress/CloudFormation/vmx.yaml
@@ -318,7 +318,7 @@ Resources:
         VMTestAgentId: !Ref VMTestAgentId
         VMTestQueueARN: !Ref VMTestQueueARN
         VMToEmailDefaultFrom: !Ref VMToEmailDefaultFrom
-        VMToEmailDefaultTo: !Ref VMToEmailDefaultFrom
+        VMToEmailDefaultTo: !Ref VMToEmailDefaultTo
       TemplateURL:
         !Join
         - ''


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Fixed incorrect use of `VMToEmailDefaultFrom` where `VMToEmailDefaultTo` should be used.
- Part change from #110 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
